### PR TITLE
fix: Broken Access Control - @PreAuthorize por role nos endpoints

### DIFF
--- a/src/main/java/com/example/EstoqueManager/config/GlobalExceptionHandler.java
+++ b/src/main/java/com/example/EstoqueManager/config/GlobalExceptionHandler.java
@@ -5,6 +5,7 @@ import java.util.Map;
 
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.AccessDeniedException;
 import org.springframework.validation.FieldError;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ControllerAdvice;
@@ -37,6 +38,13 @@ public class GlobalExceptionHandler {
 	}
 
 	//TRATAMENTO DOS DEMAIS ERROS DA APLICAÇÃO E DE REGRAS DE NEGÓCIO
+	@ExceptionHandler(AccessDeniedException.class)
+	public ResponseEntity<Map<String, String>> handleAccessDenied(AccessDeniedException ex) {
+		Map<String, String> erro = new HashMap<>();
+		erro.put("error", "Acesso negado: voce nao tem permissao para executar esta acao.");
+		return new ResponseEntity<Map<String, String>>(erro, HttpStatus.FORBIDDEN);
+	}
+
 	@ExceptionHandler(Exception.class)
 	public ResponseEntity<String> handle03(Exception ex) {
 		ex.printStackTrace();

--- a/src/main/java/com/example/EstoqueManager/controller/CategoriaController.java
+++ b/src/main/java/com/example/EstoqueManager/controller/CategoriaController.java
@@ -6,6 +6,7 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -14,6 +15,7 @@ import java.util.List;
 @RequestMapping("/api/emanager")
 @RequiredArgsConstructor
 @CrossOrigin(origins = "*", allowedHeaders = "*", allowCredentials = "false")
+@PreAuthorize("hasAuthority('ADM')")
 public class CategoriaController {
 
     private final CategoriaService categoriaService;

--- a/src/main/java/com/example/EstoqueManager/controller/CompradorController.java
+++ b/src/main/java/com/example/EstoqueManager/controller/CompradorController.java
@@ -6,6 +6,7 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -14,6 +15,7 @@ import java.util.List;
 @RequestMapping("/api/emanager")
 @RequiredArgsConstructor
 @CrossOrigin(origins = "*", allowedHeaders = "*", allowCredentials = "false")
+@PreAuthorize("hasAnyAuthority('ADM','VENDEDOR')")
 public class CompradorController {
 
     private final CompradorService compradorService;
@@ -40,6 +42,7 @@ public class CompradorController {
         return ResponseEntity.ok(compradorService.updateById(id, compradorUpdated));
     }
 
+    @PreAuthorize("hasAuthority('ADM')")
     @DeleteMapping("/comprador/delete/{id}")
     public ResponseEntity<Void> deleteById(@PathVariable Long id) {
         compradorService.deleteById(id);

--- a/src/main/java/com/example/EstoqueManager/controller/ProdutoController.java
+++ b/src/main/java/com/example/EstoqueManager/controller/ProdutoController.java
@@ -10,6 +10,7 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -18,6 +19,7 @@ import java.util.List;
 @RequestMapping("/api/emanager")
 @RequiredArgsConstructor
 @CrossOrigin(origins = "*", allowedHeaders = "*", allowCredentials = "false")
+@PreAuthorize("hasAnyAuthority('ADM','VENDEDOR')")
 public class ProdutoController {
 
     private final ProdutoService produtoService;
@@ -60,12 +62,14 @@ public class ProdutoController {
         return ResponseEntity.ok(produtoDTO);
     }
 
+    @PreAuthorize("hasAuthority('ADM')")
     @GetMapping("/produto/curva-abc")
     public ResponseEntity<List<ProdutoCurvaABCDTO>> getCurvaABC() {
         List<ProdutoCurvaABCDTO> curvaABC = produtoService.getCurvaABC();
         return ResponseEntity.ok(curvaABC);
     }
 
+    @PreAuthorize("hasAuthority('ADM')")
     @DeleteMapping("/produto/delete/{id}")
     public ResponseEntity<Void> deleteById(@PathVariable Long id) {
         produtoService.deleteById(id);

--- a/src/main/java/com/example/EstoqueManager/controller/UsuarioController.java
+++ b/src/main/java/com/example/EstoqueManager/controller/UsuarioController.java
@@ -2,6 +2,7 @@
 package com.example.EstoqueManager.controller;
 
 import com.example.EstoqueManager.dto.LoginDTO;
+import com.example.EstoqueManager.dto.UsuarioResumoDTO;
 import com.example.EstoqueManager.service.LoginService;
 import com.example.EstoqueManager.model.UsuarioModel;
 import com.example.EstoqueManager.service.UsuarioService;
@@ -34,6 +35,12 @@ public class UsuarioController {
     @GetMapping("/user/findAll")
     public ResponseEntity<List<UsuarioModel>> findAll() {
         return ResponseEntity.ok(usuarioService.findAll());
+    }
+
+    @PreAuthorize("hasAnyAuthority('ADM','VENDEDOR')")
+    @GetMapping("/user/findAllResumido")
+    public ResponseEntity<List<UsuarioResumoDTO>> findAllResumido() {
+        return ResponseEntity.ok(usuarioService.findAllResumido());
     }
 
     @PreAuthorize("hasAuthority('ADM')")

--- a/src/main/java/com/example/EstoqueManager/controller/UsuarioController.java
+++ b/src/main/java/com/example/EstoqueManager/controller/UsuarioController.java
@@ -9,6 +9,7 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -29,16 +30,19 @@ public class UsuarioController {
         return new ResponseEntity<>(token, HttpStatus.OK);
     }
     
+    @PreAuthorize("hasAuthority('ADM')")
     @GetMapping("/user/findAll")
     public ResponseEntity<List<UsuarioModel>> findAll() {
         return ResponseEntity.ok(usuarioService.findAll());
     }
 
+    @PreAuthorize("hasAuthority('ADM')")
     @GetMapping("/user/findById/{id}")
     public ResponseEntity<UsuarioModel> findById(@PathVariable Long id) {
         return ResponseEntity.ok(usuarioService.findById(id));
     }
 
+    @PreAuthorize("hasAuthority('ADM')")
     @PostMapping("/user/save")
     public ResponseEntity<UsuarioModel> save(@Valid @RequestBody UsuarioModel usuario) {
         return ResponseEntity.status(HttpStatus.CREATED).body(usuarioService.save(usuario));
@@ -55,12 +59,14 @@ public class UsuarioController {
     }
 
 
+    @PreAuthorize("hasAuthority('ADM')")
     @DeleteMapping("/user/delete/{id}")
     public ResponseEntity<Void> deleteById(@PathVariable Long id) {
         usuarioService.deleteById(id);
         return ResponseEntity.noContent().build();
     }
 
+    @PreAuthorize("hasAuthority('ADM')")
     @PutMapping("/user/update/{id}")
     public ResponseEntity<UsuarioModel> update(
             @PathVariable Long id,

--- a/src/main/java/com/example/EstoqueManager/controller/VendaController.java
+++ b/src/main/java/com/example/EstoqueManager/controller/VendaController.java
@@ -10,6 +10,7 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -18,6 +19,7 @@ import java.util.List;
 @RequestMapping("/api/emanager")
 @RequiredArgsConstructor
 @CrossOrigin(origins = "*", allowedHeaders = "*", allowCredentials = "false")
+@PreAuthorize("hasAnyAuthority('ADM','VENDEDOR')")
 public class VendaController {
 
     private final VendaService vendaService;

--- a/src/main/java/com/example/EstoqueManager/dto/UsuarioResumoDTO.java
+++ b/src/main/java/com/example/EstoqueManager/dto/UsuarioResumoDTO.java
@@ -1,0 +1,16 @@
+package com.example.EstoqueManager.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class UsuarioResumoDTO {
+    private Long id;
+    private String nome;
+
+    public UsuarioResumoDTO(Long id, String nome) {
+        this.id = id;
+        this.nome = nome;
+    }
+}

--- a/src/main/java/com/example/EstoqueManager/service/UsuarioService.java
+++ b/src/main/java/com/example/EstoqueManager/service/UsuarioService.java
@@ -1,5 +1,6 @@
 package com.example.EstoqueManager.service;
 
+import com.example.EstoqueManager.dto.UsuarioResumoDTO;
 import com.example.EstoqueManager.exception.BusinessException;
 import com.example.EstoqueManager.exception.ResourceNotFoundException;
 import com.example.EstoqueManager.model.Cargo;
@@ -36,6 +37,12 @@ public class UsuarioService {
 
     public List<UsuarioModel> findAll() {
         return usuarioRepository.findAll();
+    }
+
+    public List<UsuarioResumoDTO> findAllResumido() {
+        return usuarioRepository.findAll().stream()
+                .map(u -> new UsuarioResumoDTO(u.getId(), u.getNome()))
+                .toList();
     }
 
     public UsuarioModel findById(Long id) {


### PR DESCRIPTION
## Resumo
Corrige Broken Access Control (roles validadas so no frontend) adicionando `@PreAuthorize` por role em todos os controllers. Ver FINDING-02 no repo [estoquemanager-security-assessment](https://github.com/SantosKristhian/estoquemanager-security-assessment/blob/main/findings/FINDING-02-broken-access-control.md).

- `UsuarioController`, `CategoriaController`: ADM
- `ProdutoController`, `VendaController`, `CompradorController`: ADM+VENDEDOR (delete e curva-abc de produto: so ADM)
- Adiciona `GET /user/findAllResumido` (id+nome, sem PII) para o dropdown de "usuario responsavel" da tela de vendas, que quebrava com o `/user/findAll` restrito a ADM.
- Adiciona handler de `AccessDeniedException` no `GlobalExceptionHandler` (sem ele, bloqueio de role virava 400 em vez de 403).

Testado manualmente: login VENDEDOR -> 403 em endpoint admin, 200 em endpoint liberado; login ADM -> 200 em tudo (regressao ok).

## Problema conhecido - correcao no proximo sprint
Ao testar em conjunto com o frontend, identificamos que `GET /categoria/findAll` ficou 403 para VENDEDOR, mas a tela de produtos (liberada para VENDEDOR) depende desse endpoint so para popular o dropdown de categoria do produto e exibir o nome da categoria - nao para gerenciar categorias.

Plano definido: liberar `findAll`/`findById` de `CategoriaController` para `ADM`+`VENDEDOR` (leitura), mantendo `save`/`update`/`delete` restritos a `ADM` - mesmo padrao ja usado no `ProdutoController`. Sera feito em branch separada na proxima sessao.

## Test plan
- [x] `mvn compile`
- [x] Teste manual de login VENDEDOR/ADM contra os endpoints protegidos
- [ ] Corrigir `/categoria/findAll` para leitura de VENDEDOR (proximo sprint)