### PR TITLE
fix: libera leitura de categoria para VENDEDOR

### DIFF
--- a/src/main/java/com/example/EstoqueManager/controller/CategoriaController.java
+++ b/src/main/java/com/example/EstoqueManager/controller/CategoriaController.java
@@ -15,26 +15,29 @@ import java.util.List;
 @RequestMapping("/api/emanager")
 @RequiredArgsConstructor
 @CrossOrigin(origins = "*", allowedHeaders = "*", allowCredentials = "false")
-@PreAuthorize("hasAuthority('ADM')")
 public class CategoriaController {
 
     private final CategoriaService categoriaService;
 
+    @PreAuthorize("hasAnyAuthority('ADM','VENDEDOR')")
     @GetMapping("/categoria/findAll")
     public ResponseEntity<List<CategoriaModel>> findAll() {
         return ResponseEntity.ok(categoriaService.findAll());
     }
 
+    @PreAuthorize("hasAnyAuthority('ADM','VENDEDOR')")
     @GetMapping("/categoria/findById/{id}")
     public ResponseEntity<CategoriaModel> findById(@PathVariable Long id) {
         return ResponseEntity.ok(categoriaService.findById(id));
     }
 
+    @PreAuthorize("hasAuthority('ADM')")
     @PostMapping("/categoria/save")
     public ResponseEntity<CategoriaModel> save(@Valid @RequestBody CategoriaModel categoria) {
         return ResponseEntity.status(HttpStatus.CREATED).body(categoriaService.save(categoria));
     }
 
+    @PreAuthorize("hasAuthority('ADM')")
     @PutMapping("/categoria/update/{id}")
     public ResponseEntity<CategoriaModel> update(
             @PathVariable Long id,
@@ -42,6 +45,7 @@ public class CategoriaController {
         return ResponseEntity.ok(categoriaService.updateById(id, categoriaUpdated));
     }
 
+    @PreAuthorize("hasAuthority('ADM')")
     @DeleteMapping("/categoria/delete/{id}")
     public ResponseEntity<Void> deleteById(@PathVariable Long id) {
         categoriaService.deleteById(id);


### PR DESCRIPTION
## Resumo
Fecha o pendente deixado no PR #4: `GET /categoria/findAll` e `findById` ficaram ADM-only, mas a tela de produtos (liberada para VENDEDOR) depende deles so para popular o dropdown/exibir nome da categoria - nao para gerenciar categorias.

`CategoriaController`: `findAll`/`findById` -> ADM+VENDEDOR (leitura); `save`/`update`/`delete` continuam ADM-only. Mesmo padrao do `ProdutoController`.

Testado manualmente: VENDEDOR 200 em findAll, 403 em save; ADM 200 em tudo (regressao ok).

Referencia: FINDING-02 (secao "Acompanhamento") em [estoquemanager-security-assessment](https://github.com/SantosKristhian/estoquemanager-security-assessment/blob/main/findings/FINDING-02-broken-access-control.md).