### PR TITLE
fix: mensagem amigavel para erro de integridade referencial

### DIFF
--- a/src/main/java/com/example/EstoqueManager/config/GlobalExceptionHandler.java
+++ b/src/main/java/com/example/EstoqueManager/config/GlobalExceptionHandler.java
@@ -3,6 +3,7 @@ package com.example.EstoqueManager.config;
 import java.util.HashMap;
 import java.util.Map;
 
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.AccessDeniedException;
@@ -43,6 +44,14 @@ public class GlobalExceptionHandler {
 		Map<String, String> erro = new HashMap<>();
 		erro.put("error", "Acesso negado: voce nao tem permissao para executar esta acao.");
 		return new ResponseEntity<Map<String, String>>(erro, HttpStatus.FORBIDDEN);
+	}
+
+	//TRATAMENTO DE VIOLACAO DE INTEGRIDADE REFERENCIAL (ex: excluir categoria com produtos vinculados)
+	@ExceptionHandler(DataIntegrityViolationException.class)
+	public ResponseEntity<Map<String, String>> handleDataIntegrityViolation(DataIntegrityViolationException ex) {
+		Map<String, String> erro = new HashMap<>();
+		erro.put("error", "Não é possível concluir a operação: este registro está vinculado a outros dados do sistema.");
+		return new ResponseEntity<Map<String, String>>(erro, HttpStatus.CONFLICT);
 	}
 
 	@ExceptionHandler(Exception.class)


### PR DESCRIPTION
## Resumo
Excluir um registro com vinculos (ex: categoria com produtos associados) lancava `DataIntegrityViolationException`, que caia no handler generico do `GlobalExceptionHandler` e devolvia a mensagem crua do Hibernate/SQL pro cliente (algo como "could not execute statement... constraint fails...").

Adiciona um `@ExceptionHandler(DataIntegrityViolationException.class)` especifico: `409 Conflict` com mensagem legivel (`{"error": "Nao e possivel concluir a operacao: este registro esta vinculado a outros dados do sistema."}`).

Motivado por uma limpeza de UX no frontend (troca de `alert()`/mensagens tecnicas por um sistema de toast) - sem esse fix, o frontend continuaria expondo erro tecnico do banco nesse caso especifico.

## Test plan
- [x] `mvn compile`
- [x] Teste manual: `DELETE /categoria/delete/{id}` numa categoria com produto vinculado -> 409 com mensagem amigavel (antes: 400 com mensagem crua do Hibernate)