### PR TITLE
fix: relatorio de vendas nao mostrava usuario/comprador

### DIFF
--- a/src/main/java/com/example/EstoqueManager/controller/VendaController.java
+++ b/src/main/java/com/example/EstoqueManager/controller/VendaController.java
@@ -1,6 +1,7 @@
 package com.example.EstoqueManager.controller;
 
 import com.example.EstoqueManager.dto.VendaRequestDTO;
+import com.example.EstoqueManager.dto.VendaResponseDTO;
 import com.example.EstoqueManager.model.Cargo;
 import com.example.EstoqueManager.model.VendaModel;
 import com.example.EstoqueManager.model.UsuarioModel;
@@ -17,6 +18,7 @@ import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
+import java.util.stream.Collectors;
 
 @RestController
 @RequestMapping("/api/emanager")
@@ -31,17 +33,21 @@ public class VendaController {
 
 
     @GetMapping("/venda/findAll")
-    public ResponseEntity<List<VendaModel>> findAll() {
-        return ResponseEntity.ok(vendaService.listarVendas());
+    public ResponseEntity<List<VendaResponseDTO>> findAll() {
+        List<VendaResponseDTO> vendas = vendaService.listarVendas().stream()
+                .map(vendaService::converterParaDTO)
+                .collect(Collectors.toList());
+        return ResponseEntity.ok(vendas);
     }
 
     @GetMapping("/venda/findById/{id}")
-    public ResponseEntity<VendaModel> findById(@PathVariable Long id) {
-        return ResponseEntity.ok(vendaService.buscarVendaPorId(id));
+    public ResponseEntity<VendaResponseDTO> findById(@PathVariable Long id) {
+        VendaModel venda = vendaService.buscarVendaPorId(id);
+        return ResponseEntity.ok(vendaService.converterParaDTO(venda));
     }
 
     @PostMapping("/venda/save/{usuarioId}")
-    public ResponseEntity<VendaModel> criarVenda(
+    public ResponseEntity<VendaResponseDTO> criarVenda(
             @PathVariable Long usuarioId,
             @Valid @RequestBody VendaRequestDTO vendaRequestDTO,
             @AuthenticationPrincipal UsuarioModel usuarioAutenticado) {
@@ -53,14 +59,15 @@ public class VendaController {
 
         VendaModel venda = vendaService.criarVendaAPartirDTO(vendaRequestDTO, usuarioId);
 
-        return ResponseEntity.status(HttpStatus.CREATED).body(venda);
+        return ResponseEntity.status(HttpStatus.CREATED).body(vendaService.converterParaDTO(venda));
     }
 
     @PutMapping("/venda/update/{id}")
-    public ResponseEntity<VendaModel> updateVenda(
+    public ResponseEntity<VendaResponseDTO> updateVenda(
             @PathVariable Long id,
             @Valid @RequestBody VendaModel vendaAtualizada) {
 
-        return ResponseEntity.ok(vendaService.updateVenda(id, vendaAtualizada));
+        VendaModel venda = vendaService.updateVenda(id, vendaAtualizada);
+        return ResponseEntity.ok(vendaService.converterParaDTO(venda));
     }
 }

--- a/src/main/java/com/example/EstoqueManager/dto/VendaResponseDTO.java
+++ b/src/main/java/com/example/EstoqueManager/dto/VendaResponseDTO.java
@@ -1,0 +1,48 @@
+package com.example.EstoqueManager.dto;
+
+import com.example.EstoqueManager.model.MetodoPagamento;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Getter
+@Setter
+public class VendaResponseDTO {
+    private Long id;
+    private LocalDateTime data;
+    private double valortotal;
+    private boolean ativo;
+    private MetodoPagamento metodoPagamento;
+    private Double valorPago;
+    private Double troco;
+    private Boolean itensDevolvidos;
+
+    private UsuarioResumoDTO usuario;
+    private CompradorResumoDTO comprador;
+    private List<ItemVendaResumoDTO> itens;
+
+    @Getter
+    @Setter
+    public static class CompradorResumoDTO {
+        private Long id;
+        private String nome;
+    }
+
+    @Getter
+    @Setter
+    public static class ProdutoResumoDTO {
+        private Long id;
+        private String nome;
+    }
+
+    @Getter
+    @Setter
+    public static class ItemVendaResumoDTO {
+        private Long id;
+        private ProdutoResumoDTO produto;
+        private Integer quantidadeVendida;
+        private Double precoVendido;
+    }
+}

--- a/src/main/java/com/example/EstoqueManager/service/VendaService.java
+++ b/src/main/java/com/example/EstoqueManager/service/VendaService.java
@@ -1,6 +1,8 @@
 package com.example.EstoqueManager.service;
 
+import com.example.EstoqueManager.dto.UsuarioResumoDTO;
 import com.example.EstoqueManager.dto.VendaRequestDTO;
+import com.example.EstoqueManager.dto.VendaResponseDTO;
 import com.example.EstoqueManager.exception.BusinessException;
 import com.example.EstoqueManager.exception.ResourceNotFoundException;
 import com.example.EstoqueManager.model.*;
@@ -15,6 +17,7 @@ import org.springframework.stereotype.Service;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -406,5 +409,48 @@ public class VendaService {
             produto.setQuantidade(produto.getQuantidade() + itemAntigo.getQuantidadeVendida());
             produtoRepository.save(produto);
         }
+    }
+
+    public VendaResponseDTO converterParaDTO(VendaModel venda) {
+        VendaResponseDTO dto = new VendaResponseDTO();
+        dto.setId(venda.getId());
+        dto.setData(venda.getData());
+        dto.setValortotal(venda.getValortotal());
+        dto.setAtivo(venda.isAtivo());
+        dto.setMetodoPagamento(venda.getMetodoPagamento());
+        dto.setValorPago(venda.getValorPago());
+        dto.setTroco(venda.getTroco());
+        dto.setItensDevolvidos(venda.getItensDevolvidos());
+
+        if (venda.getUsuario() != null) {
+            dto.setUsuario(new UsuarioResumoDTO(venda.getUsuario().getId(), venda.getUsuario().getNome()));
+        }
+
+        if (venda.getComprador() != null) {
+            VendaResponseDTO.CompradorResumoDTO compradorDTO = new VendaResponseDTO.CompradorResumoDTO();
+            compradorDTO.setId(venda.getComprador().getId());
+            compradorDTO.setNome(venda.getComprador().getNome());
+            dto.setComprador(compradorDTO);
+        }
+
+        if (venda.getItens() != null) {
+            dto.setItens(venda.getItens().stream().map(item -> {
+                VendaResponseDTO.ItemVendaResumoDTO itemDTO = new VendaResponseDTO.ItemVendaResumoDTO();
+                itemDTO.setId(item.getId());
+                itemDTO.setQuantidadeVendida(item.getQuantidadeVendida());
+                itemDTO.setPrecoVendido(item.getPrecoVendido());
+
+                if (item.getProduto() != null) {
+                    VendaResponseDTO.ProdutoResumoDTO produtoDTO = new VendaResponseDTO.ProdutoResumoDTO();
+                    produtoDTO.setId(item.getProduto().getId());
+                    produtoDTO.setNome(item.getProduto().getNome());
+                    itemDTO.setProduto(produtoDTO);
+                }
+
+                return itemDTO;
+            }).collect(Collectors.toList()));
+        }
+
+        return dto;
     }
 }


### PR DESCRIPTION
## Resumo
`VendaModel.usuario` e `VendaModel.comprador` estao anotados com `@JsonBackReference` (par do `@JsonManagedReference` em `UsuarioModel.vendas`/`CompradorModel.vendas`, usado pra evitar recursao infinita). O Jackson omite esses campos por completo ao serializar a partir da venda - por isso `/venda/findAll` e `/venda/findById` nunca devolviam `usuario`/`comprador`, e o relatório de vendas sempre caía no fallback `"-"`.

Cria `VendaResponseDTO` (usuario/comprador/produto resumidos - so id+nome, sem os campos sensiveis nem o ciclo de referencia) e converte a resposta dos 4 endpoints do `VendaController` pra ele, seguindo o mesmo padrao ja usado em `ProdutoResponseDTO`.

**Nenhuma mudança necessaria no frontend** - os templates ja esperavam `venda.usuario?.nome` / `venda.comprador?.nome`, so nao vinham no payload.

## Test plan
- [x] `mvn compile`
- [x] Teste manual: `GET /venda/findAll` agora retorna `usuario`/`comprador` completos (antes vinham ausentes do JSON)