### PR TITLE
feat: log de auditoria para Produto, Usuario e Venda

### DIFF
--- a/src/main/java/com/example/EstoqueManager/controller/AuditoriaController.java
+++ b/src/main/java/com/example/EstoqueManager/controller/AuditoriaController.java
@@ -1,0 +1,37 @@
+package com.example.EstoqueManager.controller;
+
+import com.example.EstoqueManager.model.AuditoriaModel;
+import com.example.EstoqueManager.service.AuditoriaService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/emanager/auditoria")
+@RequiredArgsConstructor
+@CrossOrigin(origins = "*", allowedHeaders = "*", allowCredentials = "false")
+@PreAuthorize("hasAuthority('ADM')")
+public class AuditoriaController {
+
+    private final AuditoriaService auditoriaService;
+
+    @GetMapping("/findAll")
+    public ResponseEntity<List<AuditoriaModel>> findAll() {
+        return ResponseEntity.ok(auditoriaService.listarTudo());
+    }
+
+    @GetMapping("/entidade/{entidade}")
+    public ResponseEntity<List<AuditoriaModel>> findByEntidade(@PathVariable String entidade) {
+        return ResponseEntity.ok(auditoriaService.listarPorEntidade(entidade.toUpperCase()));
+    }
+
+    @GetMapping("/entidade/{entidade}/{entidadeId}")
+    public ResponseEntity<List<AuditoriaModel>> findByRegistro(
+            @PathVariable String entidade,
+            @PathVariable Long entidadeId) {
+        return ResponseEntity.ok(auditoriaService.listarPorRegistro(entidade.toUpperCase(), entidadeId));
+    }
+}

--- a/src/main/java/com/example/EstoqueManager/dto/auditoria/ProdutoAuditSnapshot.java
+++ b/src/main/java/com/example/EstoqueManager/dto/auditoria/ProdutoAuditSnapshot.java
@@ -1,0 +1,31 @@
+package com.example.EstoqueManager.dto.auditoria;
+
+import com.example.EstoqueManager.model.ProdutoModel;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class ProdutoAuditSnapshot {
+    private Long id;
+    private String nome;
+    private Integer quantidade;
+    private Double preco;
+    private Boolean ativo;
+    private Long categoriaId;
+    private String categoriaNome;
+
+    public static ProdutoAuditSnapshot de(ProdutoModel produto) {
+        ProdutoAuditSnapshot snapshot = new ProdutoAuditSnapshot();
+        snapshot.setId(produto.getId());
+        snapshot.setNome(produto.getNome());
+        snapshot.setQuantidade(produto.getQuantidade());
+        snapshot.setPreco(produto.getPreco());
+        snapshot.setAtivo(produto.getAtivo());
+        if (produto.getCategoria() != null) {
+            snapshot.setCategoriaId(produto.getCategoria().getId());
+            snapshot.setCategoriaNome(produto.getCategoria().getNome());
+        }
+        return snapshot;
+    }
+}

--- a/src/main/java/com/example/EstoqueManager/dto/auditoria/UsuarioAuditSnapshot.java
+++ b/src/main/java/com/example/EstoqueManager/dto/auditoria/UsuarioAuditSnapshot.java
@@ -1,0 +1,28 @@
+package com.example.EstoqueManager.dto.auditoria;
+
+import com.example.EstoqueManager.model.UsuarioModel;
+import lombok.Getter;
+import lombok.Setter;
+
+// Nao inclui a senha (nem hash) de proposito - log de auditoria nao deve guardar credenciais.
+@Getter
+@Setter
+public class UsuarioAuditSnapshot {
+    private Long id;
+    private String nome;
+    private String cpf;
+    private Integer idade;
+    private String login;
+    private String cargo;
+
+    public static UsuarioAuditSnapshot de(UsuarioModel usuario) {
+        UsuarioAuditSnapshot snapshot = new UsuarioAuditSnapshot();
+        snapshot.setId(usuario.getId());
+        snapshot.setNome(usuario.getNome());
+        snapshot.setCpf(usuario.getCpf());
+        snapshot.setIdade(usuario.getIdade());
+        snapshot.setLogin(usuario.getLogin());
+        snapshot.setCargo(usuario.getCargo() != null ? usuario.getCargo().name() : null);
+        return snapshot;
+    }
+}

--- a/src/main/java/com/example/EstoqueManager/dto/auditoria/VendaAuditSnapshot.java
+++ b/src/main/java/com/example/EstoqueManager/dto/auditoria/VendaAuditSnapshot.java
@@ -1,0 +1,42 @@
+package com.example.EstoqueManager.dto.auditoria;
+
+import com.example.EstoqueManager.model.MetodoPagamento;
+import com.example.EstoqueManager.model.VendaModel;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class VendaAuditSnapshot {
+    private Long id;
+    private Double valortotal;
+    private Boolean ativo;
+    private MetodoPagamento metodoPagamento;
+    private Double valorPago;
+    private Double troco;
+    private Boolean itensDevolvidos;
+    private Long usuarioId;
+    private String usuarioNome;
+    private Long compradorId;
+    private String compradorNome;
+
+    public static VendaAuditSnapshot de(VendaModel venda) {
+        VendaAuditSnapshot snapshot = new VendaAuditSnapshot();
+        snapshot.setId(venda.getId());
+        snapshot.setValortotal(venda.getValortotal());
+        snapshot.setAtivo(venda.isAtivo());
+        snapshot.setMetodoPagamento(venda.getMetodoPagamento());
+        snapshot.setValorPago(venda.getValorPago());
+        snapshot.setTroco(venda.getTroco());
+        snapshot.setItensDevolvidos(venda.getItensDevolvidos());
+        if (venda.getUsuario() != null) {
+            snapshot.setUsuarioId(venda.getUsuario().getId());
+            snapshot.setUsuarioNome(venda.getUsuario().getNome());
+        }
+        if (venda.getComprador() != null) {
+            snapshot.setCompradorId(venda.getComprador().getId());
+            snapshot.setCompradorNome(venda.getComprador().getNome());
+        }
+        return snapshot;
+    }
+}

--- a/src/main/java/com/example/EstoqueManager/model/AcaoAuditoria.java
+++ b/src/main/java/com/example/EstoqueManager/model/AcaoAuditoria.java
@@ -1,0 +1,7 @@
+package com.example.EstoqueManager.model;
+
+public enum AcaoAuditoria {
+    CRIACAO,
+    ATUALIZACAO,
+    EXCLUSAO
+}

--- a/src/main/java/com/example/EstoqueManager/model/AuditoriaModel.java
+++ b/src/main/java/com/example/EstoqueManager/model/AuditoriaModel.java
@@ -1,0 +1,49 @@
+package com.example.EstoqueManager.model;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "auditoria_table")
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class AuditoriaModel {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private String entidade;
+
+    @Column(nullable = false)
+    private Long entidadeId;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private AcaoAuditoria acao;
+
+    @Column(nullable = true)
+    private Long usuarioId;
+
+    @Column(nullable = false)
+    private String usuarioNome;
+
+    @Column(nullable = false)
+    private LocalDateTime dataHora;
+
+    @Lob
+    @Column(columnDefinition = "TEXT")
+    private String dadosAntes;
+
+    @Lob
+    @Column(columnDefinition = "TEXT")
+    private String dadosDepois;
+}

--- a/src/main/java/com/example/EstoqueManager/repository/AuditoriaRepository.java
+++ b/src/main/java/com/example/EstoqueManager/repository/AuditoriaRepository.java
@@ -1,0 +1,15 @@
+package com.example.EstoqueManager.repository;
+
+import com.example.EstoqueManager.model.AuditoriaModel;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface AuditoriaRepository extends JpaRepository<AuditoriaModel, Long> {
+
+    List<AuditoriaModel> findByEntidadeOrderByDataHoraDesc(String entidade);
+
+    List<AuditoriaModel> findByEntidadeAndEntidadeIdOrderByDataHoraDesc(String entidade, Long entidadeId);
+
+    List<AuditoriaModel> findAllByOrderByDataHoraDesc();
+}

--- a/src/main/java/com/example/EstoqueManager/service/AuditoriaService.java
+++ b/src/main/java/com/example/EstoqueManager/service/AuditoriaService.java
@@ -1,0 +1,72 @@
+package com.example.EstoqueManager.service;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.example.EstoqueManager.model.AcaoAuditoria;
+import com.example.EstoqueManager.model.AuditoriaModel;
+import com.example.EstoqueManager.model.UsuarioModel;
+import com.example.EstoqueManager.repository.AuditoriaRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class AuditoriaService {
+
+    private final AuditoriaRepository auditoriaRepository;
+    private final ObjectMapper objectMapper;
+
+    public void registrar(String entidade, Long entidadeId, AcaoAuditoria acao, Object dadosAntes, Object dadosDepois) {
+        UsuarioModel usuarioAutenticado = obterUsuarioAutenticado();
+
+        AuditoriaModel log = new AuditoriaModel();
+        log.setEntidade(entidade);
+        log.setEntidadeId(entidadeId);
+        log.setAcao(acao);
+        log.setUsuarioId(usuarioAutenticado != null ? usuarioAutenticado.getId() : null);
+        log.setUsuarioNome(usuarioAutenticado != null ? usuarioAutenticado.getNome() : "sistema");
+        log.setDataHora(LocalDateTime.now());
+        log.setDadosAntes(paraJson(dadosAntes));
+        log.setDadosDepois(paraJson(dadosDepois));
+
+        auditoriaRepository.save(log);
+    }
+
+    public List<AuditoriaModel> listarTudo() {
+        return auditoriaRepository.findAllByOrderByDataHoraDesc();
+    }
+
+    public List<AuditoriaModel> listarPorEntidade(String entidade) {
+        return auditoriaRepository.findByEntidadeOrderByDataHoraDesc(entidade);
+    }
+
+    public List<AuditoriaModel> listarPorRegistro(String entidade, Long entidadeId) {
+        return auditoriaRepository.findByEntidadeAndEntidadeIdOrderByDataHoraDesc(entidade, entidadeId);
+    }
+
+    private String paraJson(Object dados) {
+        if (dados == null) {
+            return null;
+        }
+        try {
+            return objectMapper.writeValueAsString(dados);
+        } catch (Exception e) {
+            log.error("Falha ao serializar snapshot de auditoria", e);
+            return null;
+        }
+    }
+
+    private UsuarioModel obterUsuarioAutenticado() {
+        Authentication auth = SecurityContextHolder.getContext().getAuthentication();
+        if (auth != null && auth.getPrincipal() instanceof UsuarioModel usuario) {
+            return usuario;
+        }
+        return null;
+    }
+}

--- a/src/main/java/com/example/EstoqueManager/service/ProdutoService.java
+++ b/src/main/java/com/example/EstoqueManager/service/ProdutoService.java
@@ -2,8 +2,10 @@ package com.example.EstoqueManager.service;
 
 import com.example.EstoqueManager.dto.ProdutoCurvaABCDTO;
 import com.example.EstoqueManager.dto.ProdutoResponseDTO;
+import com.example.EstoqueManager.dto.auditoria.ProdutoAuditSnapshot;
 import com.example.EstoqueManager.exception.BusinessException;
 import com.example.EstoqueManager.exception.ResourceNotFoundException;
+import com.example.EstoqueManager.model.AcaoAuditoria;
 import com.example.EstoqueManager.model.ItemVendaModel;
 import com.example.EstoqueManager.model.ProdutoModel;
 import com.example.EstoqueManager.model.UsuarioModel;
@@ -26,6 +28,7 @@ public class ProdutoService {
     private final ProdutoRepository produtoRepository;
     private final CategoriaRepository categoriaRepository;
     private final ItemVendaRepository itemVendaRepository;
+    private final AuditoriaService auditoriaService;
 
     public List<ProdutoModel> findAll() {
         return produtoRepository.findAll();
@@ -121,7 +124,9 @@ public class ProdutoService {
         produto.setDataUltimaAlteracao(LocalDateTime.now());
         produto.setAtivo(true); // Define como ativo ao criar
 
-        return produtoRepository.save(produto);
+        ProdutoModel salvo = produtoRepository.save(produto);
+        auditoriaService.registrar("PRODUTO", salvo.getId(), AcaoAuditoria.CRIACAO, null, ProdutoAuditSnapshot.de(salvo));
+        return salvo;
     }
 
     public ProdutoModel updateByID(Long id, ProdutoModel produtoUpdated, UsuarioModel usuario) {
@@ -142,6 +147,8 @@ public class ProdutoService {
             throw new ResourceNotFoundException("Categoria não encontrada com ID: " + produtoUpdated.getCategoria().getId());
         }
 
+        ProdutoAuditSnapshot antes = ProdutoAuditSnapshot.de(produtoExistente);
+
         produtoExistente.setNome(produtoUpdated.getNome());
         produtoExistente.setQuantidade(produtoUpdated.getQuantidade());
         produtoExistente.setPreco(produtoUpdated.getPreco());
@@ -150,7 +157,9 @@ public class ProdutoService {
         produtoExistente.setUsuarioUltimaAlteracao(usuario);
         produtoExistente.setDataUltimaAlteracao(LocalDateTime.now());
 
-        return produtoRepository.save(produtoExistente);
+        ProdutoModel salvo = produtoRepository.save(produtoExistente);
+        auditoriaService.registrar("PRODUTO", salvo.getId(), AcaoAuditoria.ATUALIZACAO, antes, ProdutoAuditSnapshot.de(salvo));
+        return salvo;
     }
 
     public void deleteById(Long id) {
@@ -161,6 +170,8 @@ public class ProdutoService {
         ProdutoModel produto = produtoRepository.findById(id)
                 .orElseThrow(() -> new ResourceNotFoundException("Produto não encontrado com ID: " + id));
 
+        ProdutoAuditSnapshot antes = ProdutoAuditSnapshot.de(produto);
+
         // Verifica se o produto está em alguma venda
         boolean produtoEmUso = itemVendaRepository.findAll().stream()
                 .anyMatch(item -> item.getProduto().getId().equals(id));
@@ -169,10 +180,12 @@ public class ProdutoService {
             // Soft delete - marca como inativo ao invés de deletar
             produto.setAtivo(false);
             produto.setDataUltimaAlteracao(LocalDateTime.now());
-            produtoRepository.save(produto);
+            ProdutoModel salvo = produtoRepository.save(produto);
+            auditoriaService.registrar("PRODUTO", id, AcaoAuditoria.ATUALIZACAO, antes, ProdutoAuditSnapshot.de(salvo));
         } else {
             // Hard delete - deleta realmente se não está em nenhuma venda
             produtoRepository.deleteById(id);
+            auditoriaService.registrar("PRODUTO", id, AcaoAuditoria.EXCLUSAO, antes, null);
         }
     }
 

--- a/src/main/java/com/example/EstoqueManager/service/UsuarioService.java
+++ b/src/main/java/com/example/EstoqueManager/service/UsuarioService.java
@@ -1,8 +1,10 @@
 package com.example.EstoqueManager.service;
 
 import com.example.EstoqueManager.dto.UsuarioResumoDTO;
+import com.example.EstoqueManager.dto.auditoria.UsuarioAuditSnapshot;
 import com.example.EstoqueManager.exception.BusinessException;
 import com.example.EstoqueManager.exception.ResourceNotFoundException;
+import com.example.EstoqueManager.model.AcaoAuditoria;
 import com.example.EstoqueManager.model.Cargo;
 import com.example.EstoqueManager.model.UsuarioModel;
 import com.example.EstoqueManager.repository.UsuarioRepository;
@@ -18,6 +20,7 @@ public class UsuarioService {
 
     private final UsuarioRepository usuarioRepository;
     private final PasswordEncoder passwordEncoder;
+    private final AuditoriaService auditoriaService;
 
     UsuarioModel autenticar(String login, String senha) {
         UsuarioModel usuario = usuarioRepository.findByLogin(login);
@@ -68,7 +71,9 @@ public class UsuarioService {
 
         usuario.setSenha(passwordEncoder.encode(usuario.getSenha()));
 
-        return usuarioRepository.save(usuario);
+        UsuarioModel salvo = usuarioRepository.save(usuario);
+        auditoriaService.registrar("USUARIO", salvo.getId(), AcaoAuditoria.CRIACAO, null, UsuarioAuditSnapshot.de(salvo));
+        return salvo;
     }
 
     public void deleteById(Long id) {
@@ -76,11 +81,11 @@ public class UsuarioService {
             throw new BusinessException("ID inválido. Deve ser um número positivo.");
         }
 
-        if (!usuarioRepository.existsById(id)) {
-            throw new ResourceNotFoundException("Usuário não encontrado com ID: " + id);
-        }
+        UsuarioModel usuario = usuarioRepository.findById(id)
+                .orElseThrow(() -> new ResourceNotFoundException("Usuário não encontrado com ID: " + id));
 
         usuarioRepository.deleteById(id);
+        auditoriaService.registrar("USUARIO", id, AcaoAuditoria.EXCLUSAO, UsuarioAuditSnapshot.de(usuario), null);
     }
 
     public UsuarioModel updateByID(Long id, UsuarioModel usuarioUpdated) {
@@ -100,13 +105,18 @@ public class UsuarioService {
             }
         }
 
+        UsuarioAuditSnapshot antes = UsuarioAuditSnapshot.de(usuarioExistente);
+
         usuarioExistente.setNome(usuarioUpdated.getNome());
         usuarioExistente.setCpf(usuarioUpdated.getCpf());
         usuarioExistente.setIdade(usuarioUpdated.getIdade());
         usuarioExistente.setLogin(usuarioUpdated.getLogin());
         usuarioExistente.setSenha(passwordEncoder.encode(usuarioUpdated.getSenha()));
         usuarioExistente.setCargo(usuarioUpdated.getCargo());
-        return usuarioRepository.save(usuarioExistente);
+
+        UsuarioModel salvo = usuarioRepository.save(usuarioExistente);
+        auditoriaService.registrar("USUARIO", salvo.getId(), AcaoAuditoria.ATUALIZACAO, antes, UsuarioAuditSnapshot.de(salvo));
+        return salvo;
     }
 
     private void validarUsuario(UsuarioModel usuario) {

--- a/src/main/java/com/example/EstoqueManager/service/VendaService.java
+++ b/src/main/java/com/example/EstoqueManager/service/VendaService.java
@@ -1,6 +1,7 @@
 package com.example.EstoqueManager.service;
 
 import com.example.EstoqueManager.dto.VendaRequestDTO;
+import com.example.EstoqueManager.dto.auditoria.VendaAuditSnapshot;
 import com.example.EstoqueManager.exception.BusinessException;
 import com.example.EstoqueManager.exception.ResourceNotFoundException;
 import com.example.EstoqueManager.model.*;
@@ -24,6 +25,7 @@ public class VendaService {
     private final ProdutoRepository produtoRepository;
     private final UsuarioRepository usuarioRepository;
     private final CompradorRepository compradorRepository;
+    private final AuditoriaService auditoriaService;
 
     public List<VendaModel> listarVendas() {
         return vendaRepository.findAll();
@@ -177,7 +179,9 @@ public class VendaService {
             throw new BusinessException("Usuário responsável pela venda é obrigatório.");
         }
 
-        return vendaRepository.save(venda);
+        VendaModel salva = vendaRepository.save(venda);
+        auditoriaService.registrar("VENDA", salva.getId(), AcaoAuditoria.CRIACAO, null, VendaAuditSnapshot.de(salva));
+        return salva;
     }
 
     // Método auxiliar para validar produto (pode já existir no seu service)
@@ -229,6 +233,8 @@ public class VendaService {
         VendaModel vendaExistente = vendaRepository.findById(id)
                 .orElseThrow(() -> new ResourceNotFoundException("Venda não encontrada com ID: " + id));
 
+        VendaAuditSnapshot antes = VendaAuditSnapshot.de(vendaExistente);
+
         // Verifica se está tentando cancelar uma venda já cancelada
         if (!vendaExistente.isAtivo() && !vendaAtualizada.isAtivo()) {
             throw new BusinessException("Esta venda já está cancelada.");
@@ -256,7 +262,9 @@ public class VendaService {
             // Marca a venda como cancelada
             vendaExistente.setAtivo(false);
 
-            return vendaRepository.save(vendaExistente);
+            VendaModel salva = vendaRepository.save(vendaExistente);
+            auditoriaService.registrar("VENDA", salva.getId(), AcaoAuditoria.ATUALIZACAO, antes, VendaAuditSnapshot.de(salva));
+            return salva;
         }
 
         // LÓGICA DE ATUALIZAÇÃO NORMAL (se a venda ainda está ativa)
@@ -308,7 +316,9 @@ public class VendaService {
             processarPagamento(vendaExistente);
         }
 
-        return vendaRepository.save(vendaExistente);
+        VendaModel salva = vendaRepository.save(vendaExistente);
+        auditoriaService.registrar("VENDA", salva.getId(), AcaoAuditoria.ATUALIZACAO, antes, VendaAuditSnapshot.de(salva));
+        return salva;
     }
 
     private void validarVenda(VendaModel venda) {


### PR DESCRIPTION
## Resumo
Log de auditoria (CRIACAO/ATUALIZACAO/EXCLUSAO) para `Produto`, `Usuario` e `Venda`, com snapshot completo (antes/depois em JSON), interceptacao manual no Service (cada save/update/delete chama `AuditoriaService.registrar(...)`).

- Snapshots dedicados por entidade (nao serializa a entidade JPA direto - evita ciclo de referencia e payload com colecoes aninhadas). **`UsuarioAuditSnapshot` nunca inclui senha/hash.**
- Captura o usuario autenticado via `SecurityContextHolder` e timestamp automaticamente.
- `AuditoriaController`: `GET /auditoria/findAll`, `/auditoria/entidade/{entidade}`, `/auditoria/entidade/{entidade}/{id}` - todos `ADM`-only.

## Test plan
- [x] `mvn compile`
- [x] Criar/editar produto -> diff exato (quantidade, preco) no log
- [x] Escalar usuario a ADM -> mudanca de cargo registrada, senha nunca aparece em nenhum snapshot
- [x] Criar/cancelar venda -> diff (ativo, itensDevolvidos) no log
- [x] VENDEDOR recebe 403 em qualquer endpoint de /auditoria