### PR TITLE
fix: senha (hash) exposta na resposta da API de usuario

### DIFF
--- a/src/main/java/com/example/EstoqueManager/model/UsuarioModel.java
+++ b/src/main/java/com/example/EstoqueManager/model/UsuarioModel.java
@@ -54,6 +54,7 @@ public class UsuarioModel implements UserDetails {
         return authorities;
     }
 
+    @JsonIgnore
     @Override
     public String getPassword() {
         return senha;


### PR DESCRIPTION
## Resumo
`UsuarioModel implements UserDetails`, e `getPassword()` (exigido pela interface) era serializado pelo Jackson como propriedade JSON `"password"` - ignorando a protecao ja existente no campo `senha` (`@JsonProperty(access = WRITE_ONLY)`), porque o Jackson trata `getPassword()` como um getter publico independente do campo anotado.

`GET /user/findAll` e `/user/findById` (ja ADM-only) devolviam o hash bcrypt de todos os usuarios no corpo da resposta. Achado durante teste manual do log de auditoria (PR #9) - alguns registros de teste tinham senha em **texto plano** no banco, expostas tal como estavam.

Adiciona `@JsonIgnore` em `getPassword()`, mesmo padrao ja usado em `getAuthorities()`. So afeta serializacao - autenticacao continua normal.

**Fora do escopo**: os registros com senha em texto plano no banco continuam assim ate serem re-cadastrados/re-hasheados - isso e dado, nao codigo.

## Test plan
- [x] `mvn compile`
- [x] `GET /user/findAll` e `/user/findById` nao retornam mais `"password"`
- [x] Login continua funcionando normalmente