### PR TITLE
fix (CRITICAL): chave de assinatura JWT hardcoded no codigo-fonte

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,3 +3,4 @@ DB_PORT=3306
 DB_NAME=estoquemanagerdb
 DB_USERNAME=estoquemanager_app
 DB_PASSWORD=
+JWT_SECRET=

--- a/src/main/java/com/example/EstoqueManager/config/JwtServiceGenerator.java
+++ b/src/main/java/com/example/EstoqueManager/config/JwtServiceGenerator.java
@@ -9,6 +9,7 @@ import java.util.Map;
 import java.util.function.Function;
 
 import com.example.EstoqueManager.model.UsuarioModel;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.stereotype.Service;
 
@@ -19,11 +20,12 @@ import io.jsonwebtoken.io.Decoders;
 import io.jsonwebtoken.security.Keys;
 
 @Service
-public class JwtServiceGenerator {  
+public class JwtServiceGenerator {
 
 	///////////////////////////////////////////////////////
 	//Parâmetros para geração do token
-	public static final String SECRET_KEY = "UMACHAVESECRETADASUAAPIAQUIUMACHAVESECRETADASUAAPIAQUIUMACHAVESECRETADASUAAPIAQUIUMACHAVESECRETADASUAAPIAQUI";
+	@Value("${jwt.secret}")
+	private String secretKey;
 	public static final SignatureAlgorithm ALGORITMO_ASSINATURA = SignatureAlgorithm.HS256;
 	public static final int HORAS_EXPIRACAO_TOKEN = 1;
 
@@ -84,7 +86,7 @@ public class JwtServiceGenerator {
 	}
 
 	private Key getSigningKey() {
-		byte[] keyBytes = Decoders.BASE64.decode(this.SECRET_KEY);
+		byte[] keyBytes = Decoders.BASE64.decode(this.secretKey);
 		return Keys.hmacShaKeyFor(keyBytes);
 	}
 

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -7,6 +7,9 @@ spring.datasource.url=jdbc:mysql://${DB_HOST:localhost}:${DB_PORT:3306}/${DB_NAM
 spring.datasource.username=${DB_USERNAME}
 spring.datasource.password=${DB_PASSWORD}
 spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
+
+jwt.secret=${JWT_SECRET}
+
 spring.jpa.show-sql=true
 spring.jpa.properties.hibernate.format_sql=true
 


### PR DESCRIPTION
## Resumo — CRITICO

`JwtServiceGenerator.SECRET_KEY` era uma string fixa no código-fonte, **pública no repositório**. Qualquer pessoa com acesso ao repo consegue forjar um JWT válido pra **qualquer usuário, com qualquer cargo (inclusive ADM)**, sem nunca chamar `/login` nem saber senha nenhuma — bypass total de autenticação.

Confirmado via PoC: forjei um token (`login: admin`, `role: ADM`) assinado com a chave hardcoded, sem chamar `/login`, e ele funcionou normalmente em `/user/findAll` e `/auditoria/findAll` (ambos ADM-only).

## Correção
Mesma abordagem já usada pras credenciais do banco (PR #2): move a chave pra variável de ambiente.

- `@Value("${jwt.secret}")` no lugar da constante hardcoded.
- `jwt.secret=${JWT_SECRET}` no `application.properties`.
- Chave nova (64 bytes aleatórios, base64) no `.env` (não versionado).
- Trocar a chave invalida automaticamente qualquer token já emitido, incluindo os forjados.

**Efeito colateral esperado**: todos os usuários logados serão deslogados após esse merge (tokens antigos, assinados com a chave antiga, deixam de ser válidos) - isso é o remediation funcionando, não um bug.

## Test plan
- [x] `mvn compile`
- [x] Token forjado com a chave antiga -> `403` (rejeitado)
- [x] Login normal gera token com a chave nova e continua funcionando

Referência: será documentado como FINDING-06 em [estoquemanager-security-assessment](https://github.com/SantosKristhian/estoquemanager-security-assessment).