### PR TITLE
Docker: containerizar o backend (multi-stage, sem IP fixo)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,11 @@
+target/
+.git/
+.gitignore
+.env
+.env.local
+.idea/
+*.iml
+*.log
+Dockerfile
+.dockerignore
+README.md

--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,22 @@
+# Copie este arquivo para ".env" (mesma pasta do docker-compose.yml / pom.xml) e preencha.
+# O ".env" real nunca deve ser commitado.
+# Usado tanto pelo Spring Boot (rodando local, fora do Docker) quanto pelo docker-compose.
+
+# --- Banco de dados ---
+# DB_HOST/DB_PORT so importam quando o backend roda fora do Docker
+# (dentro do compose, o backend usa o hostname do servico "database").
 DB_HOST=localhost
 DB_PORT=3306
 DB_NAME=estoquemanagerdb
 DB_USERNAME=estoquemanager_app
 DB_PASSWORD=
+# Senha do usuario root do MySQL - so usada pelo container "database" do compose.
+DB_ROOT_PASSWORD=
+
+# --- Autenticacao ---
+# Gere uma chave forte, ex: openssl rand -base64 32
 JWT_SECRET=
+
+# --- Portas expostas no host (apenas docker-compose, opcional, tem default) ---
+BACKEND_PORT=8080
+FRONTEND_PORT=8081

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,27 @@
+# --- Etapa de build ---
+FROM eclipse-temurin:21-jdk AS build
+WORKDIR /app
+
+# Copia primeiro só o necessário para resolver dependências (cache de camada)
+COPY .mvn/ .mvn/
+COPY mvnw pom.xml ./
+RUN sed -i 's/\r$//' mvnw && chmod +x mvnw
+RUN ./mvnw dependency:go-offline -B
+
+# Agora copia o código-fonte e builda
+COPY src/ src/
+RUN ./mvnw clean package -DskipTests -B
+
+# --- Etapa de execução ---
+FROM eclipse-temurin:21-jre AS runtime
+WORKDIR /app
+
+RUN addgroup --system spring && adduser --system --ingroup spring spring
+COPY --from=build /app/target/*.jar app.jar
+RUN chown spring:spring app.jar
+USER spring
+
+EXPOSE 8080
+
+# --enable-preview é exigido pelo compilador configurado no pom.xml
+ENTRYPOINT ["java", "--enable-preview", "-jar", "app.jar"]

--- a/README.md
+++ b/README.md
@@ -15,6 +15,39 @@ Projeto se trata de um sistem de gerenciamento de estoque, feito em JAVA + Sprin
 
 ---------------------------------------------------------------------------
 
+## Como rodar (Docker Compose)
+
+Sobe backend + frontend + MySQL com um único comando, sem depender de IP fixo de rede.
+
+### Pré-requisitos
+
+- Docker Desktop instalado e rodando.
+- O repositório do frontend clonado como pasta **irmã** deste repositório:
+
+```
+IdeaProjects/
+├── estoquemanager-backend/   (este repositório)
+└── estoquemanager-frontend/  (https://github.com/SantosKristhian/PM-02-4-PERIODO-FRONT)
+```
+
+### Passos
+
+1. Copie `.env.example` para `.env` nesta pasta e preencha as senhas e o `JWT_SECRET` (gere um com `openssl rand -base64 32`).
+2. Suba a stack:
+   ```bash
+   docker compose up -d --build
+   ```
+3. Acesse o frontend em `http://localhost:8081` (porta configurável via `FRONTEND_PORT` no `.env`).
+4. O banco é vazio na primeira execução - não há tela de primeiro acesso ainda, então é preciso criar o usuário administrador inicial direto no banco:
+   ```bash
+   docker compose exec database mysql -uroot -p"$DB_ROOT_PASSWORD" estoquemanagerdb -e \
+     "INSERT INTO usuario_table (nome, cpf, idade, login, senha, cargo) VALUES ('Admin', '00000000000', 30, 'admin', '<hash bcrypt>', 'ADM');"
+   ```
+   O campo `senha` precisa ser um hash bcrypt (o mesmo formato usado pelo Spring Security). Os dados ficam persistidos em um volume Docker nomeado (`mysql_data`) e sobrevivem a `docker compose down` / `up` - só se perdem com `docker compose down -v`.
+5. Para derrubar tudo: `docker compose down` (ou `down -v` para apagar também os dados do banco).
+
+---------------------------------------------------------------------------
+
 # Inventory and Sales Management System
 ## Java + Spring Boot application for managing the inventory and sales of a motorcycle shop.
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,45 @@
+services:
+  database:
+    image: mysql:8.0
+    environment:
+      MYSQL_ROOT_PASSWORD: ${DB_ROOT_PASSWORD}
+      MYSQL_DATABASE: ${DB_NAME}
+      MYSQL_USER: ${DB_USERNAME}
+      MYSQL_PASSWORD: ${DB_PASSWORD}
+    volumes:
+      - mysql_data:/var/lib/mysql
+    healthcheck:
+      test: ["CMD", "mysqladmin", "ping", "-h", "localhost", "-uroot", "-p${DB_ROOT_PASSWORD}"]
+      interval: 5s
+      timeout: 5s
+      retries: 10
+
+  backend:
+    build:
+      context: .
+    environment:
+      DB_HOST: database
+      DB_PORT: 3306
+      DB_NAME: ${DB_NAME}
+      DB_USERNAME: ${DB_USERNAME}
+      DB_PASSWORD: ${DB_PASSWORD}
+      JWT_SECRET: ${JWT_SECRET}
+    depends_on:
+      database:
+        condition: service_healthy
+    ports:
+      - "${BACKEND_PORT:-8080}:8080"
+
+  frontend:
+    build:
+      context: ../estoquemanager-frontend
+    environment:
+      BACKEND_HOST: backend
+      BACKEND_PORT: 8080
+    depends_on:
+      - backend
+    ports:
+      - "${FRONTEND_PORT:-8081}:80"
+
+volumes:
+  mysql_data:


### PR DESCRIPTION
## Resumo
- Dockerfile multi-stage (JDK 21 no build, JRE 21 no runtime) usando o Maven Wrapper existente.
- Configuracao 100% via variaveis de ambiente (DB_HOST/DB_PORT/DB_NAME/DB_USERNAME/DB_PASSWORD/JWT_SECRET) - nenhuma mudanca de codigo, so a imagem.
- `.dockerignore` para nao levar `target/`, `.git/`, `.env` etc para o contexto de build.
- Corrige line endings do `mvnw` (CRLF do Windows) dentro do proprio Dockerfile, sem tocar no arquivo versionado.

## Por que
Primeiro passo da infra reproduzivel: o backend precisa rodar em container conectando ao banco pelo **hostname do servico Docker** (ex: `database:3306`), nunca por IP fixo de rede, para sobreviver a troca de rede (wifi de casa / 5G / universidade).

## Teste manual
- `docker build` multi-stage concluido com sucesso.
- Container do backend + container MySQL na mesma rede Docker (bridge dedicada), backend configurado com `DB_HOST=<hostname do container mysql>` (nao localhost, nao IP) - conectou e criou o schema via Hibernate normalmente.
- `curl` na porta publicada (8080) retornou 403 do Spring Security como esperado (endpoint protegido), confirmando que a API esta de pe e acessivel de fora do container.
- Containers e rede de teste removidos apos a validacao.

## Test plan
- [ ] Revisar Dockerfile/.dockerignore
- [ ] Aprovar merge em `subdevelop`