### PR TITLE
Docker Compose: orquestrar backend + frontend + MySQL

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,22 @@
+# Copie este arquivo para ".env" (mesma pasta do docker-compose.yml / pom.xml) e preencha.
+# O ".env" real nunca deve ser commitado.
+# Usado tanto pelo Spring Boot (rodando local, fora do Docker) quanto pelo docker-compose.
+
+# --- Banco de dados ---
+# DB_HOST/DB_PORT so importam quando o backend roda fora do Docker
+# (dentro do compose, o backend usa o hostname do servico "database").
 DB_HOST=localhost
 DB_PORT=3306
 DB_NAME=estoquemanagerdb
 DB_USERNAME=estoquemanager_app
 DB_PASSWORD=
+# Senha do usuario root do MySQL - so usada pelo container "database" do compose.
+DB_ROOT_PASSWORD=
+
+# --- Autenticacao ---
+# Gere uma chave forte, ex: openssl rand -base64 32
 JWT_SECRET=
+
+# --- Portas expostas no host (apenas docker-compose, opcional, tem default) ---
+BACKEND_PORT=8080
+FRONTEND_PORT=8081

--- a/README.md
+++ b/README.md
@@ -15,6 +15,39 @@ Projeto se trata de um sistem de gerenciamento de estoque, feito em JAVA + Sprin
 
 ---------------------------------------------------------------------------
 
+## Como rodar (Docker Compose)
+
+Sobe backend + frontend + MySQL com um único comando, sem depender de IP fixo de rede.
+
+### Pré-requisitos
+
+- Docker Desktop instalado e rodando.
+- O repositório do frontend clonado como pasta **irmã** deste repositório:
+
+```
+IdeaProjects/
+├── estoquemanager-backend/   (este repositório)
+└── estoquemanager-frontend/  (https://github.com/SantosKristhian/PM-02-4-PERIODO-FRONT)
+```
+
+### Passos
+
+1. Copie `.env.example` para `.env` nesta pasta e preencha as senhas e o `JWT_SECRET` (gere um com `openssl rand -base64 32`).
+2. Suba a stack:
+   ```bash
+   docker compose up -d --build
+   ```
+3. Acesse o frontend em `http://localhost:8081` (porta configurável via `FRONTEND_PORT` no `.env`).
+4. O banco é vazio na primeira execução - não há tela de primeiro acesso ainda, então é preciso criar o usuário administrador inicial direto no banco:
+   ```bash
+   docker compose exec database mysql -uroot -p"$DB_ROOT_PASSWORD" estoquemanagerdb -e \
+     "INSERT INTO usuario_table (nome, cpf, idade, login, senha, cargo) VALUES ('Admin', '00000000000', 30, 'admin', '<hash bcrypt>', 'ADM');"
+   ```
+   O campo `senha` precisa ser um hash bcrypt (o mesmo formato usado pelo Spring Security). Os dados ficam persistidos em um volume Docker nomeado (`mysql_data`) e sobrevivem a `docker compose down` / `up` - só se perdem com `docker compose down -v`.
+5. Para derrubar tudo: `docker compose down` (ou `down -v` para apagar também os dados do banco).
+
+---------------------------------------------------------------------------
+
 # Inventory and Sales Management System
 ## Java + Spring Boot application for managing the inventory and sales of a motorcycle shop.
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,45 @@
+services:
+  database:
+    image: mysql:8.0
+    environment:
+      MYSQL_ROOT_PASSWORD: ${DB_ROOT_PASSWORD}
+      MYSQL_DATABASE: ${DB_NAME}
+      MYSQL_USER: ${DB_USERNAME}
+      MYSQL_PASSWORD: ${DB_PASSWORD}
+    volumes:
+      - mysql_data:/var/lib/mysql
+    healthcheck:
+      test: ["CMD", "mysqladmin", "ping", "-h", "localhost", "-uroot", "-p${DB_ROOT_PASSWORD}"]
+      interval: 5s
+      timeout: 5s
+      retries: 10
+
+  backend:
+    build:
+      context: .
+    environment:
+      DB_HOST: database
+      DB_PORT: 3306
+      DB_NAME: ${DB_NAME}
+      DB_USERNAME: ${DB_USERNAME}
+      DB_PASSWORD: ${DB_PASSWORD}
+      JWT_SECRET: ${JWT_SECRET}
+    depends_on:
+      database:
+        condition: service_healthy
+    ports:
+      - "${BACKEND_PORT:-8080}:8080"
+
+  frontend:
+    build:
+      context: ../estoquemanager-frontend
+    environment:
+      BACKEND_HOST: backend
+      BACKEND_PORT: 8080
+    depends_on:
+      - backend
+    ports:
+      - "${FRONTEND_PORT:-8081}:80"
+
+volumes:
+  mysql_data:


### PR DESCRIPTION
## Resumo
- `docker-compose.yml`: sobe os 3 servicos com um comando (`docker compose up -d --build`).
  - `database`: MySQL 8, volume nomeado persistente (`mysql_data`), healthcheck via `mysqladmin ping`.
  - `backend`: builda deste repositorio, conecta ao banco pelo hostname do servico (`database`), so sobe depois do banco ficar `healthy`.
  - `frontend`: builda do repositorio irmao (`../estoquemanager-frontend`), nginx faz proxy pro backend pelo hostname do servico (`backend`).
- `.env.example` atualizado (mantendo compatibilidade com quem roda o backend fora do Docker) com as variaveis novas: `DB_ROOT_PASSWORD`, `BACKEND_PORT`, `FRONTEND_PORT`.
- README ganhou secao "Como rodar (Docker Compose)" com o passo a passo, incluindo o layout de pastas irmas exigido e o passo manual (temporario) de criar o primeiro ADM direto no banco.

## Depende de
Esta branch parte de `feature/docker-backend` (#12) - precisa dela mergeada primeiro (ou mergear as duas juntas).

## Por que
Fecha o Sprint 4: reproduzir o ambiente inteiro com um comando so, sem IP fixo, com dados persistentes entre reinicializacoes.

## Teste manual
- `docker compose up -d --build` subiu os 3 containers com sucesso (build a partir do source de cada repo).
- `GET /` no frontend → 200; `GET /api/emanager/user/findAll` via proxy → 403 do Spring Security (prova que o proxy alcancou o backend real).
- Teste de persistencia: inseri um usuario ADM direto no banco, rodei `docker compose down` (sem `-v`) seguido de `docker compose up -d`, e o usuario continuou la - confirma que o volume nomeado funciona.
- `docker compose down` ao final para limpar.

## Pendente (fora do escopo desta PR)
Nao ha tela/endpoint de primeiro acesso ainda - o ADM inicial precisa ser inserido manualmente via SQL. Fica pra uma proxima branch, focada em bootstrap do primeiro usuario.

## Test plan
- [ ] Revisar docker-compose.yml / .env.example / README
- [ ] Aprovar merge (depois de mergear #12)