### PR TITLE
Cria ADM inicial automaticamente se o banco estiver vazio

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,3 +4,9 @@ DB_NAME=estoquemanagerdb
 DB_USERNAME=estoquemanager_app
 DB_PASSWORD=
 JWT_SECRET=
+
+# Opcional - login do ADM criado automaticamente quando o banco nao tem
+# nenhum administrador ainda (default: "admin"). A senha, se nao definida
+# aqui, e gerada aleatoriamente e impressa no log na primeira subida.
+ADMIN_LOGIN=
+ADMIN_PASSWORD=

--- a/src/main/java/com/example/EstoqueManager/config/AdminBootstrapRunner.java
+++ b/src/main/java/com/example/EstoqueManager/config/AdminBootstrapRunner.java
@@ -1,0 +1,66 @@
+package com.example.EstoqueManager.config;
+
+import com.example.EstoqueManager.model.Cargo;
+import com.example.EstoqueManager.model.UsuarioModel;
+import com.example.EstoqueManager.service.UsuarioService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.CommandLineRunner;
+import org.springframework.stereotype.Component;
+
+import java.security.SecureRandom;
+import java.util.Base64;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class AdminBootstrapRunner implements CommandLineRunner {
+
+    private final UsuarioService usuarioService;
+
+    @Value("${ADMIN_LOGIN:admin}")
+    private String adminLogin;
+
+    @Value("${ADMIN_PASSWORD:}")
+    private String adminPasswordConfigurada;
+
+    @Override
+    public void run(String... args) {
+        try {
+            if (usuarioService.existeAdministrador()) {
+                return;
+            }
+
+            String senha = adminPasswordConfigurada != null && !adminPasswordConfigurada.isBlank()
+                    ? adminPasswordConfigurada
+                    : gerarSenhaAleatoria();
+
+            UsuarioModel admin = new UsuarioModel();
+            admin.setNome("Administrador");
+            admin.setCpf("00000000000");
+            admin.setIdade(99);
+            admin.setLogin(adminLogin);
+            admin.setSenha(senha);
+            admin.setCargo(Cargo.ADM);
+
+            usuarioService.save(admin);
+
+            log.warn("=====================================================================");
+            log.warn("Nenhum administrador encontrado. Usuario ADM inicial criado:");
+            log.warn("  login: {}", adminLogin);
+            log.warn("  senha: {}", senha);
+            log.warn("Troque essa senha assim que possivel.");
+            log.warn("=====================================================================");
+        } catch (Exception e) {
+            log.error("Falha ao criar o administrador inicial automaticamente. " +
+                    "Se necessario, crie um usuario ADM manualmente.", e);
+        }
+    }
+
+    private String gerarSenhaAleatoria() {
+        byte[] bytes = new byte[12];
+        new SecureRandom().nextBytes(bytes);
+        return Base64.getUrlEncoder().withoutPadding().encodeToString(bytes);
+    }
+}


### PR DESCRIPTION
## Resumo
- Novo `AdminBootstrapRunner` (`CommandLineRunner`): na subida da aplicacao, se nao existir nenhum usuario com cargo ADM, cria um automaticamente via `UsuarioService.save` (mesma validacao, encoding bcrypt e registro de auditoria de sempre).
- Login configuravel via `ADMIN_LOGIN` (default `admin`).
- Senha: se `ADMIN_PASSWORD` nao for definida no `.env`, gera uma senha aleatoria (`SecureRandom`, 12 bytes) e imprime no log **uma unica vez** na primeira subida. Evita cair numa credencial fixa tipo "admin123" hardcoded no codigo.
- Falha ao criar (ex: constraint de unicidade) so loga erro, nao derruba a aplicacao.

## Por que
Sem isso, nao ha tela de primeiro acesso - toda vez que o banco fica vazio (ex: `docker compose down -v`, ou um banco novo pra teste), era preciso inserir o ADM manualmente via SQL pra conseguir logar. Isso automatiza esse passo com um metodo mais seguro que uma senha fixa.

## Teste manual
- Rodei localmente contra um MySQL descartavel (fora do Docker do backend, so pra isolar o teste desta branch).
- Primeira subida: log mostrou o admin sendo criado com a senha gerada; login via `POST /login` com essa senha retornou um JWT valido.
- Segunda subida (reiniciando o processo, banco intacto): nada foi logado/criado de novo - confirma que e idempotente (nao duplica).

## Test plan
- [ ] Revisar `AdminBootstrapRunner`
- [ ] Aprovar merge em `subdevelop`