### PR TITLE
fix: docker-compose nao repassava ADMIN_LOGIN/ADMIN_PASSWORD

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,6 +24,8 @@ services:
       DB_USERNAME: ${DB_USERNAME}
       DB_PASSWORD: ${DB_PASSWORD}
       JWT_SECRET: ${JWT_SECRET}
+      ADMIN_LOGIN: ${ADMIN_LOGIN}
+      ADMIN_PASSWORD: ${ADMIN_PASSWORD}
     depends_on:
       database:
         condition: service_healthy


### PR DESCRIPTION
## Resumo
docker-compose.yml nao incluia ADMIN_LOGIN/ADMIN_PASSWORD no environment do backend, entao o AdminBootstrapRunner sempre gerava senha aleatoria mesmo com essas variaveis definidas no .env.

## Teste manual
docker compose down -v + up --build: log confirma o bootstrap usando login/senha do .env, login via API retornou 200.

## Test plan
- [ ] Aprovar merge