### PR TITLE
docs: atualiza README com fluxo atual de execucao

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,19 +32,30 @@ IdeaProjects/
 
 ### Passos
 
-1. Copie `.env.example` para `.env` nesta pasta e preencha as senhas e o `JWT_SECRET` (gere um com `openssl rand -base64 32`).
+1. Copie `.env.example` para `.env` nesta pasta e preencha:
+   - Senhas do banco (`DB_PASSWORD`, `DB_ROOT_PASSWORD`) - pode ser qualquer valor, é um banco novo dentro do container.
+   - `JWT_SECRET` - **precisa ter pelo menos 256 bits decodificados** (a lib de JWT recusa chaves mais curtas). Gere uma com `openssl rand -base64 32` e cole o valor exatamente como saiu (não pode ter `-` ou `_`, só o alfabeto base64 padrão).
+   - `ADMIN_LOGIN`/`ADMIN_PASSWORD` (opcional) - veja o item 4 abaixo.
 2. Suba a stack:
    ```bash
    docker compose up -d --build
    ```
 3. Acesse o frontend em `http://localhost:8081` (porta configurável via `FRONTEND_PORT` no `.env`).
-4. O banco é vazio na primeira execução - não há tela de primeiro acesso ainda, então é preciso criar o usuário administrador inicial direto no banco:
+4. **Primeiro acesso**: se o banco estiver vazio (primeira subida, ou depois de um `down -v`), a aplicação cria um usuário ADM automaticamente e mostra a senha no log:
    ```bash
-   docker compose exec database mysql -uroot -p"$DB_ROOT_PASSWORD" estoquemanagerdb -e \
-     "INSERT INTO usuario_table (nome, cpf, idade, login, senha, cargo) VALUES ('Admin', '00000000000', 30, 'admin', '<hash bcrypt>', 'ADM');"
+   docker compose logs backend | grep -A4 AdminBootstrapRunner
    ```
-   O campo `senha` precisa ser um hash bcrypt (o mesmo formato usado pelo Spring Security). Os dados ficam persistidos em um volume Docker nomeado (`mysql_data`) e sobrevivem a `docker compose down` / `up` - só se perdem com `docker compose down -v`.
-5. Para derrubar tudo: `docker compose down` (ou `down -v` para apagar também os dados do banco).
+   Por padrão o login é `admin` e a senha é gerada aleatoriamente (aparece só essa vez, nesse log). Se quiser definir login/senha fixos em vez de aleatório, preencha `ADMIN_LOGIN`/`ADMIN_PASSWORD` no `.env` **antes** da primeira subida com o banco vazio - depois que já existe um ADM, essas variáveis não têm mais efeito (o jeito de trocar a senha depois é pela própria tela de usuários, logado).
+5. Os dados ficam persistidos em um volume Docker nomeado (`mysql_data`) e sobrevivem a `docker compose down` / `up` normalmente.
+
+### Resetar tudo do zero
+
+Pra garantir um estado limpo de verdade, use um comando só:
+```bash
+docker compose down -v
+docker compose up -d --build
+```
+`down -v` remove containers, rede **e** os volumes do compose (perde os dados do banco). Sem o `-v`, `docker compose down` remove só containers/rede e mantém os dados. `--build` sempre reconstrói as imagens a partir do Dockerfile/código atual, então não é preciso apagar imagem manualmente pra pegar uma mudança de código.
 
 ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Resumo
- Remove o passo de INSERT manual via SQL para criar o ADM (ficou obsoleto com o AdminBootstrapRunner).
- Documenta onde ver a senha gerada no log, como fixar login/senha via .env, requisitos do JWT_SECRET (>=256 bits, base64 padrao) e como resetar o ambiente do zero.

## Test plan
- [ ] Revisar README
- [ ] Aprovar merge