### PR TITLE
ci: pipeline de build e publish no Docker Hub

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,31 @@
+name: Docker Publish
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Compilar (sanity check antes de publicar)
+        run: ./mvnw -q compile
+
+      - name: Login no Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Build e push da imagem
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          push: true
+          tags: |
+            ${{ secrets.DOCKERHUB_USERNAME }}/estoquemanager-backend:latest
+            ${{ secrets.DOCKERHUB_USERNAME }}/estoquemanager-backend:${{ github.sha }}

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Sistema de gerenciamento de estoque e vendas   
 
+[![Docker Publish](https://github.com/SantosKristhian/PM-02-4-PERIODO/actions/workflows/docker-publish.yml/badge.svg)](https://github.com/SantosKristhian/PM-02-4-PERIODO/actions/workflows/docker-publish.yml)
+
 ## Aplicação desenvolvida em Java+Springboot para controle de estoque e vendas de uma loja de motos.
 
 Projeto se trata de um sistem de gerenciamento de estoque, feito em JAVA + Springboot, com o objetivo de suprir a demanda de uma aplicação que contivesse a regra de negócio CurvaABC. Para isso foi implementado também, um sistema de vendas completo.


### PR DESCRIPTION
## Resumo
- Workflow do GitHub Actions que compila (sanity check), builda a imagem Docker e publica no Docker Hub (`santoskristhian/estoquemanager-backend`, tags `latest` + sha do commit).
- Roda automaticamente a cada push na `main`.
- Badge de status adicionado no README.

## Test plan
- [ ] Aprovar merge em subdevelop
- [ ] Depois, mergear subdevelop -> main pra disparar o primeiro run real e confirmar publish no Docker Hub