### PR TITLE
feat: compose usa imagens do Docker Hub em vez de build local

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,9 @@ target/
 .env
 .env.local
 
+# Ajuste local do compose (buildar de codigo-fonte em vez de puxar do Hub)
+docker-compose.override.yml
+
 # IDE
 .idea/
 *.iml

--- a/README.md
+++ b/README.md
@@ -19,18 +19,11 @@ Projeto se trata de um sistem de gerenciamento de estoque, feito em JAVA + Sprin
 
 ## Como rodar (Docker Compose)
 
-Sobe backend + frontend + MySQL com um único comando, sem depender de IP fixo de rede.
+Sobe backend + frontend + MySQL com um único comando, sem depender de IP fixo de rede. As imagens de backend e frontend são publicadas automaticamente no Docker Hub ([santoskristhian/estoquemanager-backend](https://hub.docker.com/r/santoskristhian/estoquemanager-backend), [santoskristhian/estoquemanager-frontend](https://hub.docker.com/r/santoskristhian/estoquemanager-frontend)) - **não precisa clonar o repositório do frontend nem ter código-fonte nenhum pra rodar**, só este arquivo `docker-compose.yml` + `.env`.
 
 ### Pré-requisitos
 
 - Docker Desktop instalado e rodando.
-- O repositório do frontend clonado como pasta **irmã** deste repositório:
-
-```
-IdeaProjects/
-├── estoquemanager-backend/   (este repositório)
-└── estoquemanager-frontend/  (https://github.com/SantosKristhian/PM-02-4-PERIODO-FRONT)
-```
 
 ### Passos
 
@@ -40,8 +33,9 @@ IdeaProjects/
    - `ADMIN_LOGIN`/`ADMIN_PASSWORD` (opcional) - veja o item 4 abaixo.
 2. Suba a stack:
    ```bash
-   docker compose up -d --build
+   docker compose up -d
    ```
+   Isso puxa as imagens já publicadas no Docker Hub, não builda nada local.
 3. Acesse o frontend em `http://localhost:8081` (porta configurável via `FRONTEND_PORT` no `.env`).
 4. **Primeiro acesso**: se o banco estiver vazio (primeira subida, ou depois de um `down -v`), a aplicação cria um usuário ADM automaticamente e mostra a senha no log:
    ```bash
@@ -55,9 +49,22 @@ IdeaProjects/
 Pra garantir um estado limpo de verdade, use um comando só:
 ```bash
 docker compose down -v
-docker compose up -d --build
+docker compose up -d
 ```
-`down -v` remove containers, rede **e** os volumes do compose (perde os dados do banco). Sem o `-v`, `docker compose down` remove só containers/rede e mantém os dados. `--build` sempre reconstrói as imagens a partir do Dockerfile/código atual, então não é preciso apagar imagem manualmente pra pegar uma mudança de código.
+`down -v` remove containers, rede **e** os volumes do compose (perde os dados do banco). Sem o `-v`, `docker compose down` remove só containers/rede e mantém os dados.
+
+### Modo desenvolvimento (buildar do código local em vez de puxar do Hub)
+
+Por padrão o compose usa as imagens publicadas no Docker Hub (`latest`), não o código que está no seu disco. Se você está desenvolvendo e quer testar uma mudança que ainda não foi publicada:
+
+1. Copie `docker-compose.override.yml.example` para `docker-compose.override.yml` (não é commitado, é ajuste local).
+2. Clone o repositório do frontend como pasta **irmã** deste:
+   ```
+   IdeaProjects/
+   ├── estoquemanager-backend/   (este repositório)
+   └── estoquemanager-frontend/  (https://github.com/SantosKristhian/PM-02-4-PERIODO-FRONT)
+   ```
+3. Suba com `docker compose up -d --build` - o Compose junta automaticamente o `docker-compose.yml` com o `docker-compose.override.yml` (não precisa passar nenhuma flag `-f`), e builda local em vez de puxar do Hub.
 
 ---------------------------------------------------------------------------
 

--- a/docker-compose.override.yml.example
+++ b/docker-compose.override.yml.example
@@ -1,0 +1,24 @@
+# Copie este arquivo para "docker-compose.override.yml" (mesma pasta) para
+# buildar as imagens a partir do codigo-fonte local, em vez de so puxar do
+# Docker Hub - util durante o desenvolvimento, quando voce quer testar
+# uma mudanca que ainda nao foi publicada.
+#
+# Com build + image definidos juntos (este arquivo + o docker-compose.yml
+# combinados), rodar "docker compose up --build" builda local e usa o
+# mesmo nome de tag; sem esse arquivo, "docker compose up" so puxa a
+# imagem pronta do Docker Hub.
+#
+# Requer o repositorio do frontend clonado como pasta irma deste
+# repositorio (veja o README).
+#
+# O "docker-compose.override.yml" nao deve ser commitado - fica de fora
+# do git (.gitignore) porque e um ajuste local, especifico da sua maquina.
+
+services:
+  backend:
+    build:
+      context: .
+
+  frontend:
+    build:
+      context: ../estoquemanager-frontend

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,8 +15,7 @@ services:
       retries: 10
 
   backend:
-    build:
-      context: .
+    image: santoskristhian/estoquemanager-backend:latest
     environment:
       DB_HOST: database
       DB_PORT: 3306
@@ -33,8 +32,7 @@ services:
       - "${BACKEND_PORT:-8080}:8080"
 
   frontend:
-    build:
-      context: ../estoquemanager-frontend
+    image: santoskristhian/estoquemanager-frontend:latest
     environment:
       BACKEND_HOST: backend
       BACKEND_PORT: 8080


### PR DESCRIPTION
## Resumo
- `docker-compose.yml` principal troca `build:` por `image:` (backend e frontend) - agora puxa do Docker Hub, nao precisa mais clonar o repositorio do frontend como pasta irma pra rodar.
- Novo `docker-compose.override.yml.example`: copiado para `docker-compose.override.yml` (gitignored) reativa o build local, pra quem esta desenvolvendo. O Compose combina os dois arquivos automaticamente.
- README atualizado com os dois fluxos (rodar via Hub vs modo desenvolvimento).

## Teste manual
- Sem override: `docker compose up -d` puxou as imagens do Hub, stack completa funcionando, login testado (200).
- Com override: `docker compose up -d --build` buildou local (tag `Built`, nao `Pulled`), stack funcionando igual.
- `docker compose config` conferido nos dois cenarios pra confirmar o merge certo.

## Test plan
- [ ] Aprovar merge